### PR TITLE
bug: exclude /share for robots

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+---
+layout: none
+---
+User-agent: *
+Disallow: /share/


### PR DESCRIPTION
As requested in issue #21 I setup a robots.txt to exclude `/share`